### PR TITLE
Set up development environment with specific Python and Node.js versions

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,12 +1,17 @@
+# Use gitpod/workspace-postgres as the base image
 FROM gitpod/workspace-postgres
 
+# Set environment variables for Node.js and Python versions
 ENV NODE_VERSION=18
 ENV PYTHON_VERSION=3.8
 
+# Install the specified version of Python using pyenv and set it as global
 RUN pyenv install $PYTHON_VERSION -s \
     && pyenv global $PYTHON_VERSION
 
+# Install the specified version of Node.js using nvm, set it as current and default
 RUN bash -c 'source $HOME/.nvm/nvm.sh && nvm install $NODE_VERSION \
     && nvm use $NODE_VERSION && nvm alias default $NODE_VERSION'
 
+# Ensure the default Node.js version is used in new shell sessions
 RUN echo "nvm use default &>/dev/null" >> ~/.bashrc.d/51-nvm-fix


### PR DESCRIPTION
- Base image: gitpod/workspace-postgres.
- Installed Python 3.8 using pyenv and set it as the global version.
- Installed Node.js 18 using nvm, set it as the current version, and aliased it as default.
- Ensured the default Node.js version is used in new shell sessions by modifying .bashrc.d.

## Description

Please include a summary of the change and the issue it solves. 

Fixes #issue_number

## Type of change

(Please delete options that are not relevant)

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ⚡ New feature (non-breaking change which adds functionality)
- [ ] 📢 Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] 📄 This change requires a documentation update

## Verification Process

To ensure the changes are working as expected:

 - [ ]   Test Location: Specify the URL or path for testing.
 - [ ]   Verification Steps: Outline the steps or queries needed to validate the change. Include any data, configurations, or actions required to reproduce or see the new functionality.

## Additional Media:

- [ ] I have attached a brief loom video or screenshots showcasing the new functionality or change.

## Checklist:

- [ ] My code follows the style guidelines(PEP 8) of MindsDB.
- [ ] I have appropriately commented on my code, especially in complex areas.
- [x] Necessary documentation updates are either made or tracked in issues.
- [ ] Relevant unit and integration tests are updated or added.



